### PR TITLE
Fix docs

### DIFF
--- a/polartools/absorption.py
+++ b/polartools/absorption.py
@@ -76,15 +76,17 @@ def load_absorption(scan, source, positioner=None, detector=None, monitor=None,
     monitor : string, optional
         Name of the monitor detector. If None is passed, it defaults to the ion
         chamber 4.
-    transmission: bool, optional
+    transmission : bool, optional
         Flag to select between transmission mode -> ln(monitor/detector)
         or fluorescence mode -> detector/monitor
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 
@@ -141,12 +143,14 @@ def load_lockin(scan, source, positioner=None, dc_col=None, ac_col=None,
     acoff_col : string, optional
         Name of the AC offset scaler. If None is passed, it defaults to
         'Lock AC off'.
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 
@@ -207,12 +211,14 @@ def load_dichro(scan, source, positioner=None, detector=None, monitor=None,
     transmission: bool, optional
         Flag to select between transmission mode -> ln(monitor/detector)
         or fluorescence mode -> detector/monitor.
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 
@@ -298,12 +304,14 @@ def load_multi_xas(scans, source, return_mean=True, positioner=None,
     transmission: bool, optional
         Flag to select between transmission mode -> ln(monitor/detector)
         or fluorescence mode -> detector/monitor
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 
@@ -379,12 +387,14 @@ def load_multi_dichro(scans, source, return_mean=True, positioner=None,
     transmission: bool, optional
         Flag to select between transmission mode -> ln(monitor/detector)
         or fluorescence mode -> detector/monitor
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 
@@ -470,12 +480,14 @@ def load_multi_lockin(scans, source, return_mean=True, positioner=None,
     acoff_col : string, optional
         Name of the AC offset scaler. If None is passed, it defaults to
         'Lock AC off'.
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 

--- a/polartools/diffraction.py
+++ b/polartools/diffraction.py
@@ -214,7 +214,7 @@ def fit_series(
                 e.g. SampK (sample temperature), optional.
         - String starting with #metadata, reads metadata from CSV baseline
 
-        If list, information on metadata to be read: List starting with #P, #U 
+        If list, information on metadata to be read: List starting with #P, #U
         or #Q for motor positions, user values or Q-position, optional:
 
         - #P ['#P', row, element_number], e.g. ['#P', 2, 0]

--- a/polartools/diffraction.py
+++ b/polartools/diffraction.py
@@ -105,20 +105,23 @@ def load_info(source, scan_id, info, **kwargs):
     scan : int
         Scan_id our uid. If scan_id is passed, it will load the last scan with
         that scan_id.
-    info: list
-        SPEC: Information on metadata to be read: List starting with #P, #U or #Q for
-            motor positions, user values or Q-position:
-            #P: ['#P', row, element_number], e.g. ['#P', 2, 0]
-            #U: ['#U', Variable, element_number], e.g. ['#U', 'KepkoI', 1]
-            #Q: ['#Q', None, element_number], e.g. ['#Q', None, 0]
-        CSV: #metadata_name
+    info : list
+        If SPEC, information on metadata to be read: List starting with #P, #U
+        or #Q for motor positions, user values or Q-position:
 
-    kwargs:
+        - #P: ['#P', row, element_number], e.g. ['#P', 2, 0]
+        - #U: ['#U', Variable, element_number], e.g. ['#U', 'KepkoI', 1]
+        - #Q: ['#Q', None, element_number], e.g. ['#Q', None, 0]
+
+        If CSV, #metadata_name
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 
@@ -190,10 +193,9 @@ def fit_series(
     **kwargs,
 ):
     """
-    Fit series of scan with reflection profile of choice and provide fit parameters as list.
+    Fit series of scans with chosen functional and returns fit parameters.
 
     Uses lmfit (https://lmfit.github.io/lmfit-py/).
-
 
     Parameters
     ----------
@@ -201,20 +203,24 @@ def fit_series(
         Note that applicable kwargs depend on this selection.
     scan_series : int
         start, stop, step, [start2, stop2, step2, ... ,startn, stopn, stepn]
-    model:
+    model : str
         fit model: Gaussian, Lorentian, Voigt, PseidoVoigt
-    output:
+    output : bool
         Output fit parameters and plot data+fit for each scan.
-    var_series: string or list
-        string:
-            - Varying variable for scan series to be read from scan (detector),
+    var_series : string or list
+        If string
+
+        - Varying variable for scan series to be read from scan (detector),
                 e.g. SampK (sample temperature), optional.
-            - String starting with #metadata, reads metadata from CSV baseline
-        list: Information on metadata to be read: List starting with #P, #U or #Q for
-            motor positions, user values or Q-position, optional:
-            #P: ['#P', row, element_number], e.g. ['#P', 2, 0]
-            #U: ['#U', Variable, element_number], e.g. ['#U', 'KepkoI', 1]
-            #Q: ['#Q', None, element_number], e.g. ['#Q', None, 0]
+        - String starting with #metadata, reads metadata from CSV baseline
+
+        If list, information on metadata to be read: List starting with #P, #U 
+        or #Q for motor positions, user values or Q-position, optional:
+
+        - #P ['#P', row, element_number], e.g. ['#P', 2, 0]
+        - #U ['#U', Variable, element_number], e.g. ['#U', 'KepkoI', 1]
+        - #Q ['#Q', None, element_number], e.g. ['#Q', None, 0]
+
         If None, successive scans will be numbered starting from zero.
     positioner : string, optional
         Name of the positioner, this needs to be the same as defined in
@@ -225,14 +231,16 @@ def fit_series(
     monitor : string, optional
         Name of the monitor detector. If None is passed, it defaults to the ion
         chamber 3.
-    normalize: boolean
+    normalize : boolean
         Normalization to selected/default monitor on/off
-    kwargs:
-        The necessary kwargs are passed to the loading and fitting functions defined by the
+    kwargs :
+        The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 

--- a/polartools/load_data.py
+++ b/polartools/load_data.py
@@ -159,11 +159,12 @@ def load_table(scan, source, **kwargs):
     """
     Automated scan table loader.
 
-    The automation is based on the source argument:
-        - if source == 'csv' -> uses `load_csv`.
-        - else if source is a string or nexus2spec.spec.SpecDataFile -> uses
-        `load_spec`.
-        - else -> uses `load_databroker`.
+    The automation is based on the source argument.
+
+    - if source == 'csv' -> uses `load_csv`.
+    - else if source is a string or nexus2spec.spec.SpecDataFile -> uses \
+    `load_spec`.
+    - else -> uses `load_databroker`.
 
     Parameters
     ----------
@@ -172,12 +173,14 @@ def load_table(scan, source, **kwargs):
         that scan_id. See kwargs for search options.
     source : databroker database, name of the spec file, or 'csv'
         Note that applicable kwargs depend on this selection.
-    kwargs:
+    kwargs :
         The necessary kwargs are passed to the loading functions defined by the
         `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 

--- a/polartools/manage_database.py
+++ b/polartools/manage_database.py
@@ -1,16 +1,15 @@
 """
 Functions to import and export Bluesky data.
 
+.. autosummary::
+   ~to_databroker
+   ~to_csv_json
+   ~from_databroker_inplace
+   ~remove_catalog
 """
 
 # Copyright (c) 2021, UChicago Argonne, LLC.
 # See LICENSE file for details.
-
-# .. autosummary::
-#    ~to_databroker
-#    ~to_csv_json
-#    ~from_databroker_inplace
-#    ~remove_catalog
 
 from databroker_pack import (export_catalog, write_documents_manifest,
                              write_msgpack_catalog_file, unpack_inplace)

--- a/polartools/manage_database.py
+++ b/polartools/manage_database.py
@@ -1,15 +1,16 @@
 """
 Functions to import and export Bluesky data.
 
-.. autosummary::
-   ~to_databroker
-   ~to_csv_json
-   ~from_databroker_inplace
-   ~remove_catalog
 """
 
 # Copyright (c) 2021, UChicago Argonne, LLC.
 # See LICENSE file for details.
+
+# .. autosummary::
+#    ~to_databroker
+#    ~to_csv_json
+#    ~from_databroker_inplace
+#    ~remove_catalog
 
 from databroker_pack import (export_catalog, write_documents_manifest,
                              write_msgpack_catalog_file, unpack_inplace)
@@ -33,11 +34,10 @@ def to_databroker(db, folder, query=None):
     may inadvertely export a very large number of scans. See
     :func:`polartools.load_data.db_query`.
 
-    This is a narrow usage of the `databroker-pack package`_. Note that this
+    This is a narrow usage of the `databroker-pack` package_. Note that this
     package includes a convenient command line tool.
 
-    .. _databroker-pack package: \
-    https://blueskyproject.io/databroker-pack/index.html
+    .. _package: https://blueskyproject.io/databroker-pack/index.html
 
     Parameters
     ----------
@@ -49,10 +49,11 @@ def to_databroker(db, folder, query=None):
         Search parameters to select a subsection of `db`. See
         :func:`polartools.load_data.db_query` for more details.
 
-    Notes:
+    Notes
     ------
     - The scans are saved in msgpack files placed in the `folder/documents` \
     folder.
+
     - `catalog.yml` and `documents_manifest.txt` are located in `folder`.
 
     See also
@@ -75,7 +76,7 @@ def to_databroker(db, folder, query=None):
 def to_csv_json(db, folder, query=None, fname_format='scan_{}_',
                 overwrite=False, max_attempts=100):
     """
-    Exports scans into *.csv and *.json files.
+    Exports scans into .csv and .json files.
 
 
     The scans will be labeled by their `scan_id` metadata. If two or more scans
@@ -108,8 +109,8 @@ def to_csv_json(db, folder, query=None, fname_format='scan_{}_',
 
     Notes
     -----
-    - Each scan has one json "*-metadata.json" file, plus ome csv file for \
-    each data stream, for instance "*-primary.csv".
+    - Each scan has one json "-metadata.json" file, plus ome csv file for \
+    each data stream, for instance "-primary.csv".
 
     See also
     --------
@@ -155,11 +156,10 @@ def from_databroker_inplace(folder, name, merge=False):
     """
     Load the exported databroker database.
 
-    This is a narrow usage of the `databroker-pack package`_. Note that this
+    This is a narrow usage of the `databroker-pack` package_. Note that this
     package includes a convenient command line tool.
 
-    .. _databroker-pack package: \
-    https://blueskyproject.io/databroker-pack/index.html
+    .. _package: https://blueskyproject.io/databroker-pack/index.html
 
     Parameters
     ----------

--- a/polartools/pressure_calibration.py
+++ b/polartools/pressure_calibration.py
@@ -399,11 +399,13 @@ def xrd_calibrate_pressure(scan, source, bragg_peak=(1, 1, 1),
     tth_off : float, optional
         Offset between the reference two theta and the measured value.
     kwargs :
-        Passed to `polartools.load_data.load_table`. The potential kwargs are
-        passed to the loading functions defined by the `source` argument:
-            - csv        -> possible kwargs: folder, name_format
-            - spec       -> possible kwargs: folder
-            - databroker -> possible kwargs: stream, query
+        The necessary kwargs are passed to the loading functions defined by the
+        `source` argument:
+
+        - csv -> possible kwargs: folder, name_format.
+        - spec -> possible kwargs: folder.
+        - databroker -> possible kwargs: stream, query.
+
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ sphinx_copybutton
 suitcase-csv
 suitcase-json-metadata
 databroker
+databroker-pack


### PR DESCRIPTION
I noticed that the parts of the docs weren't well formatted. In particular the `polartools.manage_database` page was blank. I fixed the format using compiling in my machine (which somehow is more strict than readthedocs). Also had to add `databroker-pack` to the "requirements.txt".