### PR TITLE
Change in the load_databroker

### DIFF
--- a/polartools/absorption.py
+++ b/polartools/absorption.py
@@ -85,7 +85,7 @@ def load_absorption(scan, source, positioner=None, detector=None, monitor=None,
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
@@ -149,7 +149,7 @@ def load_lockin(scan, source, positioner=None, dc_col=None, ac_col=None,
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
@@ -217,7 +217,7 @@ def load_dichro(scan, source, positioner=None, detector=None, monitor=None,
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
@@ -310,7 +310,7 @@ def load_multi_xas(scans, source, return_mean=True, positioner=None,
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
@@ -393,7 +393,7 @@ def load_multi_dichro(scans, source, return_mean=True, positioner=None,
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
@@ -486,7 +486,7 @@ def load_multi_lockin(scans, source, return_mean=True, positioner=None,
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.

--- a/polartools/diffraction.py
+++ b/polartools/diffraction.py
@@ -118,7 +118,7 @@ def load_info(source, scan_id, info, **kwargs):
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.
@@ -237,7 +237,7 @@ def fit_series(
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.

--- a/polartools/pressure_calibration.py
+++ b/polartools/pressure_calibration.py
@@ -404,7 +404,7 @@ def xrd_calibrate_pressure(scan, source, bragg_peak=(1, 1, 1),
 
         - csv -> possible kwargs: folder, name_format.
         - spec -> possible kwargs: folder.
-        - databroker -> possible kwargs: stream, query.
+        - databroker -> possible kwargs: stream, query, use_db_v1.
 
         Note that a warning will be printed if the an unnecessary kwarg is
         passed.

--- a/polartools/tests/test_load_data.py
+++ b/polartools/tests/test_load_data.py
@@ -27,7 +27,7 @@ def test_load_csv():
 
 
 def test_load_databroker(db):
-    table = load_data.load_table(1049, db)
+    table = load_data.load_table(1049, db, use_db_v1=False)
     assert table.shape == (4, 19)
 
     table = load_data.load_table(1049, db, use_db_v1=True)

--- a/polartools/tests/test_load_data.py
+++ b/polartools/tests/test_load_data.py
@@ -15,8 +15,12 @@ def test_load_csv():
 
 def test_load_databroker():
     db = catalog['test_data']
-    table = load_data.load_table(1049, db)
+
+    table = load_data.load_table(1049, db, use_db_v1=False)
     assert table.shape == (4, 19)
+
+    table = load_data.load_table(1049, db, use_db_v1=True)
+    assert table.shape == (4, 20)
 
 
 def test_spec():


### PR DESCRIPTION
See #28. Adds the option to read the data using `databroker.v1` via the `use_db_v1` flag. For now, loading through `v1` is faster, and will be the default option.