### PR TITLE
Make all absorption.py returns numpy.array

### DIFF
--- a/polartools/absorption.py
+++ b/polartools/absorption.py
@@ -115,9 +115,15 @@ def load_absorption(scan, source, positioner=None, detector=None, monitor=None,
     table = load_table(scan, source, **kwargs)
 
     if transmission:
-        return table[positioner], np.log(table[monitor]/table[detector])
+        return (
+            table[positioner].to_numpy(),
+            np.log(table[monitor]/table[detector])
+            )
     else:
-        return table[positioner], table[detector]/table[monitor]
+        return (
+            table[positioner].to_numpy(),
+            (table[detector]/table[monitor]).to_numpy()
+            )
 
 
 def load_lockin(scan, source, positioner=None, dc_col=None, ac_col=None,
@@ -183,7 +189,8 @@ def load_lockin(scan, source, positioner=None, dc_col=None, ac_col=None,
     # Load data
     table = load_table(scan, source, **kwargs)
 
-    return table[positioner], table[dc_col], table[ac_col] - table[acoff_col]
+    return (table[positioner].to_numpy(), table[dc_col].to_numpy(),
+            (table[ac_col] - table[acoff_col]).to_numpy())
 
 
 def load_dichro(scan, source, positioner=None, detector=None, monitor=None,


### PR DESCRIPTION
Ensures that all returns from `absorption.load_absorption` and `absorption.load_lockin` are `numpy.array`. For example, here:

https://github.com/APS-4ID-POLAR/polartools/blob/2484a8f2adb6add44edac176f8fc79c1f745d006/polartools/absorption.py#L118

the first item was `pandas.Series` and second `numpy.array`. Now all will be `numpy.array`.