### PR TITLE
Fix process image

### DIFF
--- a/polartools/process_images.py
+++ b/polartools/process_images.py
@@ -250,13 +250,15 @@ def get_spectrum(image, curvature, biny=1):
 
     Returns
     -------
-    spectrum : same format as image input
+    spectrum : numpy array
         Extracted 1D spectrum.
 
     See also
     --------
     :func:`pyrixs.extract`
     """
+    if isinstance(image, da.core.Array):
+        image = image.compute()
     ph = _cleanup_photon_events(image_to_photon_events(image.transpose()))
     return extract(ph, curvature, biny=biny)
 
@@ -293,6 +295,8 @@ def get_spectra(images, curvature, biny=1):
     """
     spectra = []
     for image in images:
+        if isinstance(image, da.core.Array):
+            image = image.compute()
         spectra.append(get_spectrum(image, curvature, biny=biny))
     return np.array(spectra)
 

--- a/polartools/tests/test_process_images.py
+++ b/polartools/tests/test_process_images.py
@@ -97,7 +97,7 @@ def test_get_spectrum(im):
     )
 
     assert spectrum.shape == (264, 2)
-    assert allclose(spectrum.mean().compute(), 132.42162878787877)
+    assert allclose(spectrum.mean(), 132.42162878787877)
 
 
 def test_get_spectra(ims):


### PR DESCRIPTION
Closes #64.

There has been some change in `dask` where the conversion from `image` to `photon_events` creates an array with unknown size `size=(nan,3)`, that then fails later on.

This has been fixed by computing the image Dask Array (i.e. make it numpy.array) prior to converting into photon_events. This is related to #61, we should find a better way to process the images, maybe without making them photon events.