### PR TITLE
Fix load_dichro from hdf5 files

### DIFF
--- a/polartools/absorption.py
+++ b/polartools/absorption.py
@@ -282,7 +282,7 @@ def load_dichro(
     # In SPEC the columns are different.
     if (
         isinstance(source, (str, SpecDataFile))
-        and source != "csv"
+        and source not in ("csv", "hdf5", "h5", "hdf")
         and not is_Bluesky_specfile(source, **kwargs)
     ):
         if not positioner:


### PR DESCRIPTION
The `load_dichro` function needs to be changed to accommodate the new option to load hdf5 files. Currently it breaks because it treats it as if it was a spec file.