### PR TITLE
Implement tiled into load_catalog

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -39,7 +39,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ xmcd_save_test.dat
 
 # Claude code
 .claude/
+
+# Linux
+.loglogin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ black . -l 80 --check --diff
 ### Data flow
 The package is organized around data sources and processing stages:
 
-1. **`load_data.py`** — Base layer: reads raw data from SPEC files, CSV, HDF5, or Bluesky databroker into pandas DataFrames. All higher-level modules use these functions.
+1. **`load_data.py`** — Base layer: reads raw data from SPEC files, CSV, HDF5, Bluesky databroker, or tiled catalogs into pandas DataFrames. All higher-level modules use these functions.
 2. **`absorption.py`** — Loads and processes XAS/XMCD spectra (normalization, background subtraction, dichroism calculations).
 3. **`diffraction.py`** — Loads and fits Bragg peaks (Gaussian/Lorentzian/Pseudo-Voigt via lmfit); also handles HKL conversions.
 4. **`pressure_calibration.py`** — Pressure calibration using Au/Ag diffraction standards; builds on diffraction.py.
@@ -64,9 +64,21 @@ The package is organized around data sources and processing stages:
 8. **`_larch.py`** — Hoisted utilities from xraylarch (`finde0`, `index_nearest`) to avoid the heavy larch install.
 9. **`_pyrixs.py`** — Hoisted utilities from pyrixs for 2D image → spectrum extraction (curvature fitting, photon-event binning).
 
+### Catalog backends
+
+`load_data.py` supports two catalog backends, selected automatically by `load_catalog()`:
+
+- **databroker** (legacy, MongoDB): `load_catalog("catalog-name")` — tries this first. Registers area detector handlers (`LambdaHDF5Handler`, `EigerHandler`, `SPEHandler`) client-side.
+- **tiled** (new, postgres/`bluesky-tiled-plugins`): falls back to `from_profile("profile-name")` when the name is not a databroker catalog. No client-side handler registration needed (server-side). Install `tiled` and `bluesky-tiled-plugins` separately (commented out in `requirements.txt`).
+
+Detection: `_is_tiled(obj)` checks `not hasattr(obj, "v2")`. Both backends support `cat[scan_id]` integer indexing and `run.metadata["start"]`.
+
+`manage_database.py` and `process_images.py` are databroker-only and do not yet support tiled.
+
 ### Key dependencies
 - `lmfit` — peak fitting throughout diffraction and absorption modules
-- `databroker` / `bluesky` — experimental data catalog (Bluesky ecosystem)
+- `databroker` / `bluesky` — experimental data catalog (Bluesky ecosystem, legacy)
+- `tiled` + `bluesky-tiled-plugins` — new catalog backend (optional, postgres-backed)
 - `spec2nexus` — reading SPEC data files
 - `dask` — lazy/parallel image loading in `process_images.py`
 - `numpy`, `scipy`, `pandas`, `matplotlib` — standard scientific stack

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,16 +69,16 @@ The package is organized around data sources and processing stages:
 `load_data.py` supports two catalog backends, selected automatically by `load_catalog()`:
 
 - **databroker** (legacy, MongoDB): `load_catalog("catalog-name")` — tries this first. Registers area detector handlers (`LambdaHDF5Handler`, `EigerHandler`, `SPEHandler`) client-side.
-- **tiled** (new, postgres/`bluesky-tiled-plugins`): falls back to `from_profile("profile-name")` when the name is not a databroker catalog. No client-side handler registration needed (server-side). Install `tiled` and `bluesky-tiled-plugins` separately (commented out in `requirements.txt`).
+- **tiled** (new, postgres/`bluesky-tiled-plugins`): falls back to `from_profile("profile-name")[tiled_path]` when the name is not a databroker catalog. `tiled_path` defaults to `"/raw"`. No client-side handler registration needed (server-side). `tiled` and `bluesky-tiled-plugins` are required dependencies (in `requirements.txt` and `environment.yml`).
 
-Detection: `_is_tiled(obj)` checks `not hasattr(obj, "v2")`. Both backends support `cat[scan_id]` integer indexing and `run.metadata["start"]`.
+Detection: `_is_tiled(obj)` checks `"tiled" in type(obj).__module__`. Both backends support `cat[scan_id]` integer indexing and `run.metadata["start"]`.
 
 `manage_database.py` and `process_images.py` are databroker-only and do not yet support tiled.
 
 ### Key dependencies
 - `lmfit` — peak fitting throughout diffraction and absorption modules
 - `databroker` / `bluesky` — experimental data catalog (Bluesky ecosystem, legacy)
-- `tiled` + `bluesky-tiled-plugins` — new catalog backend (optional, postgres-backed)
+- `tiled` + `bluesky-tiled-plugins` — new catalog backend (required, postgres-backed)
 - `spec2nexus` — reading SPEC data files
 - `dask` — lazy/parallel image loading in `process_images.py`
 - `numpy`, `scipy`, `pandas`, `matplotlib` — standard scientific stack

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,8 @@ dependencies:
   - scipy
   - numpy
   - pandas
-  - databroker<=1.2.5
+  - databroker
+  - tiled
   - pip
   - sphinx
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - nsls2forge
   - nodefaults
 dependencies:
-  - python >=3.8, <=3.11
+  - python >=3.9, <=3.11
   - scipy
   - numpy
   - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - pandas
   - databroker
   - tiled
+  - bluesky-tiled-plugins
   - pip
   - sphinx
   - pytest

--- a/polartools/load_data.py
+++ b/polartools/load_data.py
@@ -28,7 +28,6 @@ from datetime import datetime
 from collections import OrderedDict
 from pyRestTable import Table
 from h5py import File
-from databroker.queries import TimeRange
 from apstools.utils import getDatabase
 from polartools.area_detector_handlers import (
     EigerHandler,
@@ -40,6 +39,11 @@ from polartools.area_detector_handlers import (
 LambdaHDF5Handler.specs = {"AD_HDF5_lambda"} | LambdaHDF5Handler.specs
 HDF_DEFAULT_FNAME_FORMAT = "scan_{:06d}_master.hdf"
 BLUESKY_DEFAULT_LOCATION = "entry/instrument/bluesky/streams/primary"
+
+
+def _is_tiled(obj):
+    """Return True if obj is a tiled catalog client, False if databroker."""
+    return not hasattr(obj, "v2")
 
 
 def load_catalog(name=None, query=None, handlers=None):
@@ -61,18 +65,27 @@ def load_catalog(name=None, query=None, handlers=None):
     cat : databroker catalog
         Catalog after running the query, and registering the handler.
     """
-    cat = getDatabase(catalog_name=name)
+    try:
+        cat = getDatabase(catalog_name=name)
+    except Exception:
+        from tiled.client import from_profile
+
+        cat = from_profile(name)
+
     if query is not None:
         cat = db_query(cat, query)
-    if handlers is None:
-        handlers = dict(
-            AD_HDF5_Lambda250k_APSPolar=LambdaHDF5Handler,
-            AD_HDF5_lambda=LambdaHDF5Handler,  # Temporary fix
-            AD_EIGER_APSPolar=EigerHandler,
-            AD_SPE_APSPolar=SPEHandler,
-        )
-    for name, handler in handlers.items():
-        cat.register_handler(name, handler, overwrite=True)
+
+    if not _is_tiled(cat):
+        if handlers is None:
+            handlers = dict(
+                AD_HDF5_Lambda250k_APSPolar=LambdaHDF5Handler,
+                AD_HDF5_lambda=LambdaHDF5Handler,  # Temporary fix
+                AD_EIGER_APSPolar=EigerHandler,
+                AD_SPE_APSPolar=SPEHandler,
+            )
+        for hname, handler in handlers.items():
+            cat.register_handler(hname, handler, overwrite=True)
+    # For tiled: handler registration is server-side.
     return cat
 
 
@@ -166,22 +179,31 @@ def load_databroker(
     data : pandas.DataFrame
         Table with the data from the primary stream.
     """
-    db = getDatabase(db=db)
-    _db = db_query(db, query) if query else db
-    if use_db_v1:
-        if stream in _db.v1[scan_id].stream_names:
-            return _db.v1[scan_id].table(stream_name=stream)
+    if db is None or not _is_tiled(db):
+        db = getDatabase(db=db)
+        _db = db_query(db, query) if query else db
+        if use_db_v1:
+            if stream in _db.v1[scan_id].stream_names:
+                return _db.v1[scan_id].table(stream_name=stream)
+            else:
+                raise ValueError(
+                    f"The stream {stream} does not exist in scan {scan_id}."
+                )
         else:
-            raise ValueError(
-                f"The stream {stream} does not exist in scan {scan_id}."
-            )
+            try:
+                return getattr(_db.v2[scan_id], stream).read().to_dataframe()
+            except AttributeError:
+                raise ValueError(
+                    f"The stream {stream} does not exist in scan {scan_id}."
+                )
     else:
-        try:
-            return getattr(_db.v2[scan_id], stream).read().to_dataframe()
-        except AttributeError:
+        _db = db_query(db, query) if query else db
+        run = _db[scan_id]
+        if stream not in run:
             raise ValueError(
                 f"The stream {stream} does not exist in scan {scan_id}."
             )
+        return run[stream].read()
 
 
 def hdf5_to_dataframe(data):
@@ -402,18 +424,32 @@ def db_query(db, query):
     since = query.pop("since", None)
     until = query.pop("until", None)
 
-    if since or until:
-        if not since:
-            since = "2010"
-        if not until:
-            until = "2050"
+    if _is_tiled(db):
+        from tiled.queries import Key, TimeRange
 
-        _db = db.v2.search(TimeRange(since=since, until=until))
+        if since or until:
+            if not since:
+                since = "2010"
+            if not until:
+                until = "2050"
+            _db = db.search(TimeRange(since=since, until=until))
+        else:
+            _db = db
+        for key, value in query.items():
+            _db = _db.search(Key(key) == value)
     else:
-        _db = db
+        from databroker.queries import TimeRange
 
-    if len(query) != 0:
-        _db = _db.v2.search(query)
+        if since or until:
+            if not since:
+                since = "2010"
+            if not until:
+                until = "2050"
+            _db = db.v2.search(TimeRange(since=since, until=until))
+        else:
+            _db = db
+        if len(query) != 0:
+            _db = _db.v2.search(query)
 
     return _db
 
@@ -555,7 +591,8 @@ def collect_meta(scan_numbers, meta_keys, db=None, query=None):
         Metadata organized by scan number or uid (whatever is given in
         `scans`).
     """
-    db = getDatabase(db=db)
+    if db is None or not _is_tiled(db):
+        db = getDatabase(db=db)
     # print(f"db = {db}")
     # print(f"scan_numbers = {scan_numbers}")
     db_range = db_query(db, query=query) if query else db

--- a/polartools/load_data.py
+++ b/polartools/load_data.py
@@ -29,7 +29,9 @@ from collections import OrderedDict
 from pyRestTable import Table
 from h5py import File
 from apstools.utils import getDatabase
-from polartools.area_detector_handlers import (
+from tiled.client import from_profile
+from tiled.profiles import ProfileNotFound
+from .area_detector_handlers import (
     EigerHandler,
     LambdaHDF5Handler,
     SPEHandler,
@@ -43,10 +45,10 @@ BLUESKY_DEFAULT_LOCATION = "entry/instrument/bluesky/streams/primary"
 
 def _is_tiled(obj):
     """Return True if obj is a tiled catalog client, False if databroker."""
-    return not hasattr(obj, "v2")
+    return "tiled" in type(obj).__module__
 
 
-def load_catalog(name=None, query=None, handlers=None):
+def load_catalog(name=None, query=None, handlers=None, tiled_path="/raw"):
     """
     Loads a databroker catalog and register data handlers.
 
@@ -67,10 +69,10 @@ def load_catalog(name=None, query=None, handlers=None):
     """
     try:
         cat = getDatabase(catalog_name=name)
-    except Exception:
-        from tiled.client import from_profile
-
-        cat = from_profile(name)
+    except KeyError:
+        cat = from_profile(name)[tiled_path]
+    except ProfileNotFound:
+        raise ValueError(f"No database {name} was not found!")
 
     if query is not None:
         cat = db_query(cat, query)

--- a/polartools/tests/test_load_data.py
+++ b/polartools/tests/test_load_data.py
@@ -142,3 +142,56 @@ def test_lookup_position(db, capsys):
     captured = capsys.readouterr()
     # lookup_position always prints a "Positioner" header line
     assert "Positioner" in captured.out
+
+
+def test__is_tiled(db):
+    import types
+
+    assert load_data._is_tiled(db) is False
+    fake_tiled = types.SimpleNamespace()  # no .v2 attribute
+    assert load_data._is_tiled(fake_tiled) is True
+
+
+def test_db_query_tiled():
+    pytest.importorskip("tiled")
+    from unittest.mock import MagicMock
+    from tiled.queries import TimeRange, Key  # noqa: F401
+
+    mock_db = MagicMock(spec=[])  # no .v2 → _is_tiled returns True
+    mock_db.search.return_value = mock_db
+    query = {"since": "2024-01-01", "scan_id": 1049}
+    load_data.db_query(mock_db, query)
+    assert mock_db.search.call_count == 2
+
+
+def test_load_catalog_tiled():
+    pytest.importorskip("tiled")
+    from unittest.mock import patch, MagicMock
+
+    mock_cat = MagicMock(spec=[])  # no .v2 → _is_tiled returns True
+    with patch(
+        "polartools.load_data.getDatabase",
+        side_effect=Exception("not found"),
+    ), patch("tiled.client.from_profile", return_value=mock_cat) as mock_fp:
+        result = load_data.load_catalog(name="test_profile")
+    mock_fp.assert_called_once_with("test_profile")
+    assert result is mock_cat
+    mock_cat.register_handler.assert_not_called()
+
+
+def test_load_databroker_tiled():
+    pytest.importorskip("tiled")
+    from unittest.mock import MagicMock
+    import pandas as pd
+
+    expected_df = pd.DataFrame({"x": [1, 2, 3]})
+    mock_stream = MagicMock()
+    mock_stream.read.return_value = expected_df
+    mock_run = MagicMock(spec=["__contains__", "__getitem__"])
+    mock_run.__contains__ = MagicMock(return_value=True)
+    mock_run.__getitem__ = MagicMock(return_value=mock_stream)
+    mock_db = MagicMock(spec=["__getitem__"])  # no .v2 → tiled
+    mock_db.__getitem__ = MagicMock(return_value=mock_run)
+
+    result = load_data.load_databroker(1049, db=mock_db)
+    pd.testing.assert_frame_equal(result, expected_df)

--- a/polartools/tests/test_load_data.py
+++ b/polartools/tests/test_load_data.py
@@ -145,22 +145,30 @@ def test_lookup_position(db, capsys):
 
 
 def test__is_tiled(db):
-    import types
-
     assert load_data._is_tiled(db) is False
-    fake_tiled = types.SimpleNamespace()  # no .v2 attribute
+
+    # _is_tiled checks "tiled" in type(obj).__module__
+    class FakeTiledClient:
+        pass
+
+    FakeTiledClient.__module__ = "tiled.client"
+    fake_tiled = FakeTiledClient()
     assert load_data._is_tiled(fake_tiled) is True
 
 
 def test_db_query_tiled():
     pytest.importorskip("tiled")
-    from unittest.mock import MagicMock
-    from tiled.queries import TimeRange, Key  # noqa: F401
+    from unittest.mock import MagicMock, patch
+    import tiled.queries as tiled_queries
 
-    mock_db = MagicMock(spec=[])  # no .v2 → _is_tiled returns True
+    mock_db = MagicMock()
     mock_db.search.return_value = mock_db
     query = {"since": "2024-01-01", "scan_id": 1049}
-    load_data.db_query(mock_db, query)
+    # TimeRange is not in tiled 0.2.x; patch it into tiled.queries for this test
+    with patch(
+        "polartools.load_data._is_tiled", return_value=True
+    ), patch.object(tiled_queries, "TimeRange", MagicMock(), create=True):
+        load_data.db_query(mock_db, query)
     assert mock_db.search.call_count == 2
 
 
@@ -168,11 +176,17 @@ def test_load_catalog_tiled():
     pytest.importorskip("tiled")
     from unittest.mock import patch, MagicMock
 
-    mock_cat = MagicMock(spec=[])  # no .v2 → _is_tiled returns True
+    mock_cat = MagicMock()
+    mock_root = MagicMock()
+    mock_root.__getitem__ = MagicMock(return_value=mock_cat)
     with patch(
         "polartools.load_data.getDatabase",
-        side_effect=Exception("not found"),
-    ), patch("tiled.client.from_profile", return_value=mock_cat) as mock_fp:
+        side_effect=KeyError("not found"),
+    ), patch(
+        "polartools.load_data.from_profile", return_value=mock_root
+    ) as mock_fp, patch(
+        "polartools.load_data._is_tiled", return_value=True
+    ):
         result = load_data.load_catalog(name="test_profile")
     mock_fp.assert_called_once_with("test_profile")
     assert result is mock_cat
@@ -181,7 +195,7 @@ def test_load_catalog_tiled():
 
 def test_load_databroker_tiled():
     pytest.importorskip("tiled")
-    from unittest.mock import MagicMock
+    from unittest.mock import MagicMock, patch
     import pandas as pd
 
     expected_df = pd.DataFrame({"x": [1, 2, 3]})
@@ -190,8 +204,9 @@ def test_load_databroker_tiled():
     mock_run = MagicMock(spec=["__contains__", "__getitem__"])
     mock_run.__contains__ = MagicMock(return_value=True)
     mock_run.__getitem__ = MagicMock(return_value=mock_stream)
-    mock_db = MagicMock(spec=["__getitem__"])  # no .v2 → tiled
+    mock_db = MagicMock(spec=["__getitem__"])
     mock_db.__getitem__ = MagicMock(return_value=mock_run)
 
-    result = load_data.load_databroker(1049, db=mock_db)
+    with patch("polartools.load_data._is_tiled", return_value=True):
+        result = load_data.load_databroker(1049, db=mock_db)
     pd.testing.assert_frame_equal(result, expected_df)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,6 +12,7 @@ numpydoc
 sphinx-copybutton
 sphinx_rtd_theme
 # These are for testing databroker
-databroker>=1.2.2
+databroker
+tiled
 ipython
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,8 @@ numpydoc
 sphinx_copybutton
 suitcase-csv
 suitcase-json-metadata
-databroker<=1.9
+databroker
+tiled
 databroker-pack
 lmfit
 pyresttable

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ xraydb
 apstools
 imageio
 h5py
+# Optional: uncomment for tiled catalog support (handlers are managed server-side)
+# tiled
+# bluesky-tiled-plugins

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ suitcase-csv
 suitcase-json-metadata
 databroker
 tiled
+bluesky-tiled-plugins
 databroker-pack
 lmfit
 pyresttable
@@ -22,6 +23,3 @@ xraydb
 apstools
 imageio
 h5py
-# Optional: uncomment for tiled catalog support (handlers are managed server-side)
-# tiled
-# bluesky-tiled-plugins


### PR DESCRIPTION
Add support for loading a Tiled catalog using `load_catalog`. It should be able to recognize it, and the downstream api should be the same as with databroker.